### PR TITLE
Some compatibility fixes

### DIFF
--- a/autoload/i3vimfocus.vim
+++ b/autoload/i3vimfocus.vim
@@ -1,7 +1,19 @@
 let s:plugin_path = escape(expand('<sfile>:p:h'), '\')
 
-exe 'pyfile ' . escape(s:plugin_path, ' ') . '/i3vimfocus.py'
+if has('python')
+	exe 'pyfile ' . escape(s:plugin_path, ' ') . '/i3vimfocus.py'
+elseif has('python3')
+	exe 'py3file ' . escape(s:plugin_path, ' ') . '/i3vimfocus.py'
+else
+	echom "Your vim installation does not support +python or +python3."
+endif
 
 function! i3vimfocus#PythonExecProcess(name, args)
-    python PythonExecSubprocess()
+	if has('python')
+		python PythonExecSubprocess()
+	elseif has('python3')
+		python3 PythonExecSubprocess()
+	else
+		echom "Your vim installation does not support +python or +python3."
+	endif
 endfunction

--- a/i3-vim-focus/src/main.rs
+++ b/i3-vim-focus/src/main.rs
@@ -51,22 +51,28 @@ fn main() {
     let direction = Direction::from_str(&name).unwrap();
 
     let xdo = xdo::Xdo::new().expect("create xdo");
-    let window = xdo.get_active_window().expect("get active x11 window");
-    let window_name = window.get_name().expect("get window name");
+    let window = xdo.get_active_window();
 
-    if window_name.contains("VIM") {
-        let sequence = format!("g+w+{}", direction.to_vim_direction());
-        let mods = xdo.get_active_modifiers().expect("get_active_modifiers");
-        window.clear_active_modifiers(&mods).expect("clear_active_modifiers");
-        window.send_keysequence("Escape", None)
-            .expect("send escape");
-        window.send_keysequence(&sequence, None)
-            .expect("send gw{}");
-        window.set_active_modifiers(&mods).expect("set_active_modifiers");
-    } else {
-        let mut conn = i3ipc::I3Connection::connect().expect("connect i3");
-        let command = format!("focus {}", name);
-        println!("sending command: {}", command);
-        conn.command(&command).expect("send i3 message");
+    if let Ok(window) = window {
+        let window_name = window.get_name();
+
+        if let Ok(window_name) = window_name {
+
+            if window_name.contains("VIM") {
+                let sequence = format!("g+w+{}", direction.to_vim_direction());
+                let mods = xdo.get_active_modifiers().expect("get_active_modifiers");
+                window.clear_active_modifiers(&mods).expect("clear_active_modifiers");
+                window.send_keysequence("Escape", None)
+                    .expect("send escape");
+                window.send_keysequence(&sequence, None)
+                    .expect("send gw{}");
+                window.set_active_modifiers(&mods).expect("set_active_modifiers");
+                return;
+            }
+        }
     }
+    let mut conn = i3ipc::I3Connection::connect().expect("connect i3");
+    let command = format!("focus {}", name);
+    println!("sending command: {}", command);
+    conn.command(&command).expect("send i3 message");
 }


### PR DESCRIPTION
 - Error handling for xdo function calls allows changing focus when no window is active (focus is on container parent for example).
 - Changes to i3vimfocus.vim provide support for python3. Shamelessly
 copied from: https://github.com/termhn/i3-vim-nav

Lemme know if you're interested?